### PR TITLE
Rust 2021, dependency upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
+## 0.2.0
+
+- [[]()] Bump MSRV to 1.56.0
+- [[]()] Dependency updates
+
 ## 0.1.2
 
-+ Added the `transliterate_string` function
-
+- Added the `transliterate_string` function

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "ironcore-search-helpers"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["IronCore Labs <code@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"
 categories = ["cryptography"]
 keywords = ["cryptography", "encrypted-search", "search"]
 description = "Search helpers for working with encrypted values, particularly on the IronCore platform."
-edition = "2018"
+edition = "2021"
+rust-version = "1.56.0"
 
 [dependencies]
-sha2 = "~0.8.1"
-lazy_static = "~1.4.0"
-itertools = "~0.10.0"
-rand = "~0.7.3"
-# We pin these so they can't vary accidentially.
+sha2 = "0.9"
+lazy_static = "1.4"
+itertools = "0.10"
+rand = "0.8"
+# We pin these so they can't vary accidentally.
 unidecode = "=0.3.0"
 unicode-segmentation = "=1.8.0"


### PR DESCRIPTION
- rand 0.8
- sha2 0.9
- Bump to Rust 2021 (requires MSRV 1.56.0)